### PR TITLE
Added JSON ResponseType with Envelope (DF-179_B2)

### DIFF
--- a/digitalforms-api/src/main/java/ca/bc/gov/open/pssg/rsbc/digitalforms/controller/IRPQueryServiceController.java
+++ b/digitalforms-api/src/main/java/ca/bc/gov/open/pssg/rsbc/digitalforms/controller/IRPQueryServiceController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
+import ca.bc.gov.open.pssg.rsbc.digitalforms.model.JSONResponse;
 import ca.bc.gov.open.pssg.rsbc.digitalforms.service.IRPQueryService;
 
 /**
@@ -25,9 +26,10 @@ public class IRPQueryServiceController {
 	IRPQueryService irpService; 
 	
 	@RequestMapping(value ="/{id}", method = RequestMethod.GET)
-	public ResponseEntity<String> irpGet(@PathVariable (value="id",required=true) Long id)  {
-	    String resp = irpService.getIRP(id); 		
-	    return new ResponseEntity<String>(resp, HttpStatus.CREATED);
+	public ResponseEntity<JSONResponse<String>> irpGet(@PathVariable (value="id",required=true) Long id)  {
+	    String data = irpService.getIRP(id);
+	    JSONResponse<String> resp = new JSONResponse<String>(data);
+	    return new ResponseEntity<JSONResponse<String>>(resp, HttpStatus.CREATED);
 	}
 
 }

--- a/digitalforms-api/src/main/java/ca/bc/gov/open/pssg/rsbc/digitalforms/model/JSONError.java
+++ b/digitalforms-api/src/main/java/ca/bc/gov/open/pssg/rsbc/digitalforms/model/JSONError.java
@@ -1,0 +1,50 @@
+package ca.bc.gov.open.pssg.rsbc.digitalforms.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+/**
+ * 
+ * Error object
+ * 
+ * @author shaunmillargov
+ *
+ */
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({ "message", "httpStatus" })
+public class JSONError {
+
+	@JsonProperty("message")
+	private String message;
+
+	@JsonProperty("httpStatus")
+	private Integer httpStatus;
+	
+	public JSONError(String message, int code) {
+		this.message = message; 
+		this.httpStatus = code; 
+	}
+
+	@JsonProperty("message")
+	public String getMessage() {
+		return message;
+	}
+
+	@JsonProperty("message")
+	public void setMessage(String message) {
+		this.message = message;
+	}
+
+	@JsonProperty("httpStatus")
+	public Integer getHttpStatus() {
+		return httpStatus;
+	}
+
+	@JsonProperty("code")
+	public void setHttpStatus(Integer httpStatus) {
+		this.httpStatus = httpStatus;
+	}
+
+}

--- a/digitalforms-api/src/main/java/ca/bc/gov/open/pssg/rsbc/digitalforms/model/JSONResponse.java
+++ b/digitalforms-api/src/main/java/ca/bc/gov/open/pssg/rsbc/digitalforms/model/JSONResponse.java
@@ -1,0 +1,61 @@
+package ca.bc.gov.open.pssg.rsbc.digitalforms.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+/**
+ * 
+ * JSON Enveloped Response Type (Variable object payload) 
+ * 
+ * @author shaunmillargov
+ *
+ * @param <T>
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({ "resp", "data", "error" })
+public class JSONResponse<T> {
+	
+	@JsonProperty("data")
+	private T data; 
+
+	@JsonProperty("resp")
+	private String resp = "Success"; 
+	
+	@JsonProperty("error")
+	private JSONError error;
+	
+	public JSONResponse(T data){
+		this.data = data; 
+	};
+	
+	public T getData() {
+		return data;
+	}
+
+	public void setData(T data) {
+		this.data = data;
+	}
+
+	@JsonProperty("resp")
+	public String getResp() {
+		return resp;
+	}
+
+	@JsonProperty("resp")
+	public void setResp(String resp) {
+		this.resp = resp;
+	}
+
+	@JsonProperty("error")
+	public JSONError getError() {
+		return error;
+	}
+
+	@JsonProperty("error")
+	public void setError(JSONError error) {
+		this.resp = "Fail"; 
+		this.error = error;
+	}
+
+}


### PR DESCRIPTION
# Description

Added enveloped JSON data type for all responses from this API.

- {DF-179#}

## Type of change

- [X] New feature (non-breaking change which adds functionality)

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Ran locally. No unit tests yet. 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
